### PR TITLE
Specify Wear Compose dependency versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,10 +55,10 @@ android {
 }
 
 dependencies {
-    implementation(platform("androidx.wear.compose:compose-bom:1.2.0"))
-    implementation("androidx.wear.compose:compose-material")
-    implementation("androidx.wear.compose:compose-foundation")
-    implementation("androidx.wear.compose:compose-navigation")
+    val wearComposeVersion = "1.3.0"
+    implementation("androidx.wear.compose:compose-material:$wearComposeVersion")
+    implementation("androidx.wear.compose:compose-foundation:$wearComposeVersion")
+    implementation("androidx.wear.compose:compose-navigation:$wearComposeVersion")
 
     implementation("androidx.activity:activity-compose:1.7.2")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")


### PR DESCRIPTION
## Summary
- replace the Wear Compose BOM with explicit versioned artifacts
- pin material, foundation, and navigation libraries to Wear Compose 1.3.0

## Testing
- ./gradlew :app:checkDebugAarMetadata *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe9afaea0832ebe9ff96cb0dce85a