### PR TITLE
Use stable watch face dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.wear:wear:1.3.0")
     // Use the latest stable Watch Face libraries published to Google Maven.
-    val watchfaceVersion = "1.3.0"
+    val watchfaceVersion = "1.2.0"
     implementation("androidx.wear.watchface:watchface:$watchfaceVersion")
     implementation("androidx.wear.watchface:watchface-style:$watchfaceVersion")
     implementation("androidx.wear.watchface:watchface-format:$watchfaceVersion")


### PR DESCRIPTION
## Summary
- switch the watchface dependency version constant to the stable 1.2.0 release
- keep all watchface artifacts referencing the shared constant

## Testing
- ./gradlew :app:assembleDebug *(fails: missing Gradle wrapper JAR in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68de02fd0e7c832e9b6172653f2345e5