### PR TITLE
Update watch face dependency version and service base class

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.wear:wear:1.3.0")
     // Use the latest stable Watch Face libraries published to Google Maven.
-    val watchfaceVersion = "1.2.0"
+    val watchfaceVersion = "1.3.0"
     implementation("androidx.wear.watchface:watchface:$watchfaceVersion")
     implementation("androidx.wear.watchface:watchface-style:$watchfaceVersion")
     implementation("androidx.wear.watchface:watchface-format:$watchfaceVersion")

--- a/app/src/main/java/com/knightworld/wear/KnightWorldWatchFaceService.kt
+++ b/app/src/main/java/com/knightworld/wear/KnightWorldWatchFaceService.kt
@@ -14,7 +14,7 @@ import androidx.wear.watchface.CanvasType
 import androidx.wear.watchface.ComplicationSlotsManager
 import androidx.wear.watchface.Renderer
 import androidx.wear.watchface.WatchFace
-import androidx.wear.watchface.WatchFaceService
+import androidx.wear.watchface.ListenableWatchFaceService
 import androidx.wear.watchface.WatchFaceType
 import androidx.wear.watchface.WatchState
 import androidx.wear.watchface.style.CurrentUserStyleRepository
@@ -25,7 +25,7 @@ import java.util.Locale
 
 private const val INTERACTIVE_UPDATE_RATE_MS = 60_000L
 
-class KnightWorldWatchFaceService : WatchFaceService() {
+class KnightWorldWatchFaceService : ListenableWatchFaceService() {
 
     override fun createComplicationSlotsManager(
         currentUserStyleRepository: CurrentUserStyleRepository


### PR DESCRIPTION
## Summary
- bump the Wear OS watch face dependency version to 1.3.0 so the watchface-format artifact resolves
- migrate KnightWorldWatchFaceService to ListenableWatchFaceService to avoid the deprecated API

## Testing
- gradle :app:checkDebugAarMetadata *(fails: Android SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de0816162c832ebdaad8917353b423