### PR TITLE
Fix KnightWorldWatchFaceService compilation issues

### DIFF
--- a/app/src/main/java/com/knightworld/wear/KnightWorldWatchFaceService.kt
+++ b/app/src/main/java/com/knightworld/wear/KnightWorldWatchFaceService.kt
@@ -13,6 +13,7 @@ import androidx.core.content.ContextCompat
 import androidx.wear.watchface.CanvasType
 import androidx.wear.watchface.ComplicationSlotsManager
 import androidx.wear.watchface.Renderer
+import androidx.wear.watchface.Renderer.SharedAssets
 import androidx.wear.watchface.WatchFace
 import androidx.wear.watchface.ListenableWatchFaceService
 import androidx.wear.watchface.WatchFaceType
@@ -26,6 +27,8 @@ import java.util.Locale
 private const val INTERACTIVE_UPDATE_RATE_MS = 60_000L
 
 class KnightWorldWatchFaceService : ListenableWatchFaceService() {
+
+    override fun createUserStyleSchema(): UserStyleSchema = UserStyleSchema(emptyList())
 
     override fun createComplicationSlotsManager(
         currentUserStyleRepository: CurrentUserStyleRepository
@@ -50,7 +53,9 @@ class KnightWorldWatchFaceService : ListenableWatchFaceService() {
         // En la versión 1.2.0, el UserStyleSchema es el tercer parámetro, sin nombre.
         return WatchFace(
             WatchFaceType.DIGITAL,
-            renderer
+            renderer,
+            complicationSlotsManager,
+            currentUserStyleRepository
         )
     }
 


### PR DESCRIPTION
## Summary
- implement the required user style schema override for the watch face service
- ensure the WatchFace constructor receives the complication manager and style repository
- import the SharedAssets type used by the renderer

## Testing
- Not run (Gradle wrapper is missing in the repository)


------
https://chatgpt.com/codex/tasks/task_e_68de108d6ad0832e8bd91534d038bf79