### PR TITLE
Align watch face creation with supported API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,10 +49,10 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.wear:wear:1.3.0")
-    // Use the latest stable Watch Face libraries published to Google Maven.
-    val watchfaceVersion = "1.4.0"
-    implementation("androidx.wear.watchface:watchface:1.3.0-alpha07")
-    implementation("androidx.wear.watchface:watchface-style:1.3.0-alpha07")
-    implementation("androidx.wear.watchface:watchface-format:watchfaceVersion")
-    implementation("androidx.wear.watchface:watchface-complications-data-source-ktx:1.2.1")
+    // Use a consistent watch face library version across dependencies.
+    val watchfaceVersion = "1.2.1"
+    implementation("androidx.wear.watchface:watchface:$watchfaceVersion")
+    implementation("androidx.wear.watchface:watchface-style:$watchfaceVersion")
+    implementation("androidx.wear.watchface:watchface-complications-data-source:$watchfaceVersion")
+    implementation("androidx.wear.watchface:watchface-complications-data-source-ktx:$watchfaceVersion")
 }

--- a/app/src/main/java/com/knightworld/wear/KnightWorldWatchFaceService.kt
+++ b/app/src/main/java/com/knightworld/wear/KnightWorldWatchFaceService.kt
@@ -13,6 +13,7 @@ import androidx.core.content.ContextCompat
 import androidx.wear.watchface.CanvasType
 import androidx.wear.watchface.ComplicationSlotsManager
 import androidx.wear.watchface.Renderer
+import androidx.wear.watchface.Renderer.SharedAssets
 import androidx.wear.watchface.WatchFace
 import androidx.wear.watchface.ListenableWatchFaceService
 import androidx.wear.watchface.WatchFaceType
@@ -26,6 +27,8 @@ import java.util.Locale
 private const val INTERACTIVE_UPDATE_RATE_MS = 60_000L
 
 class KnightWorldWatchFaceService : ListenableWatchFaceService() {
+
+    override fun createUserStyleSchema(): UserStyleSchema = UserStyleSchema(emptyList())
 
     override fun createComplicationSlotsManager(
         currentUserStyleRepository: CurrentUserStyleRepository
@@ -45,12 +48,11 @@ class KnightWorldWatchFaceService : ListenableWatchFaceService() {
             watchState
         )
 
-        // CORRECCIÓN: Pasar el UserStyleSchema directamente al constructor de WatchFace.
-        // --- CORRECCIÓN AQUÍ ---
-        // En la versión 1.2.0, el UserStyleSchema es el tercer parámetro, sin nombre.
         return WatchFace(
-            WatchFaceType.DIGITAL,
-            renderer
+            watchFaceType = WatchFaceType.DIGITAL,
+            renderer = renderer,
+            complicationSlotsManager = complicationSlotsManager,
+            currentUserStyleRepository = currentUserStyleRepository
         )
     }
 


### PR DESCRIPTION
## Summary
- construct the watch face using named parameters so the renderer is passed only once
- align the watch face dependencies on a single supported version to avoid API mismatches

## Testing
- Not run (Gradle wrapper JAR missing from the repository)


------
https://chatgpt.com/codex/tasks/task_e_68de108d6ad0832e8bd91534d038bf79